### PR TITLE
Upgrade enzyme to use react 16

### DIFF
--- a/imports/startup/client/client.test.js
+++ b/imports/startup/client/client.test.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Meteor } from 'meteor/meteor';
 import { chai } from 'meteor/practicalmeteor:chai';
 import Enzyme, { mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({ adapter: new Adapter() });
 const expect = chai.expect;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1144,17 +1144,31 @@
         "rst-selector-parser": "2.2.3"
       }
     },
-    "enzyme-adapter-react-15": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-15/-/enzyme-adapter-react-15-1.0.5.tgz",
-      "integrity": "sha512-GxQ+ZYbo6YFwwpaLc9LLyAwsx+F1au628/+hwTx3XV2OiuvHGyWgC/r1AAK1HlDRjujzfwwMNZTc/JxkjIuYVg==",
+    "enzyme-adapter-react-16": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.0.tgz",
+      "integrity": "sha512-OlZJn5PJUJ91EOQQRuISZpXgPlqT9fYR2yBZQPu9UYok+wS19Rn4teXywF34LMcyw2AzE1s0ZRDtcI952/vQHg==",
       "dev": true,
       "requires": {
         "enzyme-adapter-utils": "1.2.0",
         "lodash": "4.17.4",
         "object.assign": "4.0.4",
         "object.values": "1.0.4",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.0",
+        "react-test-renderer": "16.2.0"
+      },
+      "dependencies": {
+        "react-test-renderer": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.2.0.tgz",
+          "integrity": "sha512-Kd4gJFtpNziR9ElOE/C23LeflKLZPRpNQYWP3nQBY43SJ5a+xyEGSeMrm2zxNKXcnCbBS/q1UpD9gqd5Dv+rew==",
+          "dev": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        }
       }
     },
     "enzyme-adapter-utils": {
@@ -3780,16 +3794,6 @@
         "classnames": "2.2.5",
         "prop-types": "15.6.0",
         "react-input-autosize": "2.1.2"
-      }
-    },
-    "react-test-renderer": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.6.2.tgz",
-      "integrity": "sha1-0DM0NPwsQ4CSaWyncNpe1IA376g=",
-      "dev": true,
-      "requires": {
-        "fbjs": "0.8.16",
-        "object-assign": "4.1.1"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@meteorjs/eslint-config-meteor": "^1.0.5",
     "babel-eslint": "^8.0.3",
     "enzyme": "^3.2.0",
-    "enzyme-adapter-react-15": "^1.0.5",
+    "enzyme-adapter-react-16": "^1.1.0",
     "eslint": "^4.12.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-import-resolver-meteor": "^0.4.0",
@@ -49,8 +49,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-meteor": "^4.1.4",
     "eslint-plugin-mocha": "^4.11.0",
-    "eslint-plugin-react": "^7.5.1",
-    "react-test-renderer": "^15.6.2"
+    "eslint-plugin-react": "^7.5.1"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This pull request contains the following:
- Upgrade testing tools ( enzyme ) to be compatible with react 16