### PR TITLE
Fix selection issue in Firefox preventing drag and drop of items

### DIFF
--- a/src/components/FlowItemPanel/style.css
+++ b/src/components/FlowItemPanel/style.css
@@ -63,6 +63,7 @@
   margin-top: -10px;
   position: relative;
   z-index: 9999;
+  pointer-events: none;
 }
 ::-webkit-scrollbar {
   width: 0px;

--- a/src/components/FlowItemPanel/style.css
+++ b/src/components/FlowItemPanel/style.css
@@ -9,6 +9,7 @@
 .sidebar {
   width: 112px;
   height: 100vh;
+  user-select: none;
 }
 .sidebar .ant-card-body {
   position: fixed;


### PR DESCRIPTION
Fixes https://github.com/vanila-io/wireflow/issues/46

Live PR demo at: https://deploy-preview-51--wireflow-app.netlify.app/

![wireflow-firefox-drag-fix](https://user-images.githubusercontent.com/856222/94584516-0866f780-027f-11eb-83a5-b3a4da35f6c5.gif)

Tested in:
- [x] Firefox Nightly 83.0a1 (2020-09-28)
- [x] Chromium 85.0.4183.121

Please consider to test Wireflow in Firefox in the future as well. :smiley:

Changes discussed in https://github.com/vanila-io/wireflow/issues/46#issuecomment-700784528 and https://github.com/vanila-io/wireflow/issues/46#issuecomment-700808215