### PR TITLE
Dockerized

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*e2e
+*.git*
+*.editorconfig
+*.eslintignore
+*.eslintrc.js
+*build

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:14-alpine
 WORKDIR /app
 COPY . .
+RUN yarn
 RUN yarn build
 
 FROM nginx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:14-alpine
+WORKDIR /app
+COPY . .
+RUN yarn build
+
+FROM nginx
+WORKDIR /usr/share/nginx/html/
+COPY --from=0 /app/build/  .


### PR DESCRIPTION
A Dockerfile an a .dockerignore file has been added. This makes the application portable and easily deployable.

To build - 

`docker run -t <tagname>` 
 and then run 

`docker run -p 80:80 <tagname>`

The application will be available at `http://localhost`