### PR TITLE
adds tests for upperFirst and proptypes for DetailForm

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "e2e": "cd e2e && jest",
     "eject": "react-scripts eject",
     "start": "react-scripts start",
-    "test": "react-scripts test"
+    "test": "react-scripts test --watchAll=false"
   },
   "browserslist": {
     "production": [

--- a/src/__tests__/utils/upperFirst.test.js
+++ b/src/__tests__/utils/upperFirst.test.js
@@ -1,0 +1,13 @@
+import { upperFirst } from "../../utils";
+
+describe("upperFirst", () => {
+    it("should return one word with only first letter capitalised when one word is passed in", () => {
+        const result = upperFirst("wIREfloW");
+        expect(result).toEqual("Wireflow");
+    });
+
+    it("should return each word having only first letter capitalised when multiple words are passed in", () => {
+        const result = upperFirst("hello, wIREfloW PEOPLE");
+        expect(result).toEqual("Hello, Wireflow People");
+    });
+})

--- a/src/components/FlowDetailPanel/DetailForm/index.js
+++ b/src/components/FlowDetailPanel/DetailForm/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { withPropsAPI } from 'gg-editor';
 import Card from 'antd/es/card';
 import Input from 'antd/es/input';
@@ -197,5 +198,9 @@ class DetailForm extends React.Component {
     );
   }
 }
+
+DetailForm.propTypes = { 
+  type: PropTypes.string.isRequired
+};
 
 export default withPropsAPI(DetailForm);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,2 +1,2 @@
 export const upperFirst = (str) =>
-  str.toLowerCase().replace(/( |^)[a-z]/g, (l) => l.toUpperCase());
+  str && typeof str === "string" ? str.toLowerCase().replace(/( |^)[a-z]/g, (l) => l.toUpperCase()) : "";


### PR DESCRIPTION
Wrote a couple of tests just to confirm that the regex is working as expected. Plus, the tests would serve as an explanation of what the `upperFirst` method does. But added a null and type check to the method just in case because if for some reason `type` is falsy the app would break. This is also partly why I added the PropTypes stuff - if the `type` prop is missing or is something other than a string you'd get an error in the console saying the prop is either missing or isn't a string which would help with debugging.

As for the `--watchAll=false` flag to the test script in `package.json` so that Jest can exit after it finishes running the tests.