### PR TITLE
Docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*e2e
+*.git*
+*.editorconfig
+*.eslintignore
+*.eslintrc.js
+*build

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:14-alpine
+WORKDIR /app
+COPY . .
+RUN yarn
+RUN yarn build
+
+FROM nginx
+WORKDIR /usr/share/nginx/html/
+COPY --from=0 /app/build/  .

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ yarn start
 open http://localhost:3000
 ```
 
+# Using docker-compose
+```
+docker-compose up -d
+```
+
 ## Credits
 ### Contributors
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.5'
+
+services:
+  web:
+    image: debarshri/wireflow
+    build: .
+    ports:
+      - 8083:80
+    environment:
+      - MONGO_URL="mongodb://localhost:27018 meteor --port 3050"
+  db:
+    image: mongo:latest
+    ports:
+      - 3050:3050


### PR DESCRIPTION
Now we can put wireflow up easy with a docker-compose.

I have pulled [debarshri/wireflow repo](https://github.com/debarshri/wireflow) to get Dockerfile and created that compose file to run wireflow with mongo.